### PR TITLE
[#16] feat : 공통 컴포넌트 Tab 구현

### DIFF
--- a/src/components/DatePicker/Calendar.tsx
+++ b/src/components/DatePicker/Calendar.tsx
@@ -27,7 +27,7 @@ const CalendarItem = ({
         isInactive && "cursor-auto opacity-50",
         dayOfTheWeek === 6 && "text-saturday",
         dayOfTheWeek === 0 && "text-sunday",
-        isSelected && "rounded-[5px] border-primary bg-primary-lighten/[.34]",
+        isSelected && "bg-primary-light/[.34] rounded-[5px] border-primary",
         className,
       )}
       {...props}

--- a/src/components/Tab/TabItem.tsx
+++ b/src/components/Tab/TabItem.tsx
@@ -27,7 +27,6 @@ export interface TabItemProps
   label?: string;
   icon?: IconType;
   isActive?: boolean;
-  isDisabled?: boolean;
 }
 
 const TabItem = ({

--- a/src/components/Tab/TabItem.tsx
+++ b/src/components/Tab/TabItem.tsx
@@ -9,14 +9,14 @@ const tabItemCSS = cva("", {
   variants: {
     variant: {
       enclosed:
-        "w-40 rounded-t-[5px] border border-b-0 border-[#CCCCCC] bg-[#F2F2F2] py-2",
-      underlined: "grow border-b-2 border-[#CCCCCC] py-6 text-[#CCCCCC]",
-      solid: "rounded-sm border border-[#CCCCCC] p-1.5",
+        "border-gray-middle bg-gray-light w-40 rounded-t-[5px] border border-b-0 py-2",
+      underlined: "border-gray-middle text-gray-middle grow border-b-2 py-6",
+      solid: "border-gray-middle rounded-sm border p-1.5",
     },
     active: {
-      enclosed: "bg-[#F9F9F9]",
-      underlined: "border-[#616161] text-black",
-      solid: "border-[#06367A] bg-[#06367A]",
+      enclosed: "bg-white-dull",
+      underlined: "border-gray-dark text-black",
+      solid: "border-primary bg-primary",
     },
   },
 });
@@ -46,14 +46,14 @@ const TabItem = ({
       className={cn(
         tabItemCSS({ variant }),
         isActive && tabItemCSS({ active: variant }),
-        isDisabled && "text-[#CCCCCC]",
+        isDisabled && "text-gray-middle",
         className,
       )}
       {...props}
     >
       {Icon ? (
         <Icon
-          className={cn("size-6 text-[#616161]", isActive && "text-white")}
+          className={cn("text-gray-dark size-6", isActive && "text-white")}
         />
       ) : (
         label

--- a/src/components/Tab/TabItem.tsx
+++ b/src/components/Tab/TabItem.tsx
@@ -1,0 +1,65 @@
+import { ComponentPropsWithoutRef } from "react";
+
+import { VariantProps, cva } from "class-variance-authority";
+import { IconType } from "react-icons";
+
+import { cn } from "@/utils/cn";
+
+const tabItemCSS = cva("", {
+  variants: {
+    variant: {
+      enclosed:
+        "w-40 rounded-t-[5px] border border-b-0 border-[#CCCCCC] bg-[#F2F2F2] py-2",
+      underlined: "grow border-b-2 border-[#CCCCCC] py-6 text-[#CCCCCC]",
+      solid: "rounded-sm border border-[#CCCCCC] p-1.5",
+    },
+    active: {
+      enclosed: "bg-[#F9F9F9]",
+      underlined: "border-[#616161] text-black",
+      solid: "border-[#06367A] bg-[#06367A]",
+    },
+  },
+});
+
+export interface TabItemProps
+  extends VariantProps<typeof tabItemCSS>,
+    ComponentPropsWithoutRef<"button"> {
+  label?: string;
+  icon?: IconType;
+  isActive?: boolean;
+  isDisabled?: boolean;
+}
+
+const TabItem = ({
+  variant,
+  label = "",
+  icon,
+  isActive = false,
+  className,
+  ...props
+}: TabItemProps) => {
+  const Icon = icon;
+  const { disabled: isDisabled } = props;
+
+  return (
+    <button
+      className={cn(
+        tabItemCSS({ variant }),
+        isActive && tabItemCSS({ active: variant }),
+        isDisabled && "text-[#CCCCCC]",
+        className,
+      )}
+      {...props}
+    >
+      {Icon ? (
+        <Icon
+          className={cn("size-6 text-[#616161]", isActive && "text-white")}
+        />
+      ) : (
+        label
+      )}
+    </button>
+  );
+};
+
+export default TabItem;

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -27,6 +27,10 @@ interface TabProps
   extends VariantProps<typeof tabContentCSS>,
     ComponentPropsWithRef<"div"> {}
 
+/**
+ *  className을 지정하여 Tab Content 영역 스타일을 변경할 수 있습니다.
+ */
+
 const Tab = ({ children, className, ...props }: TabProps) => {
   const { variant } = props;
 

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -1,0 +1,61 @@
+import {
+  Children,
+  ComponentPropsWithRef,
+  ReactElement,
+  cloneElement,
+  useMemo,
+  useState,
+} from "react";
+
+import { VariantProps, cva } from "class-variance-authority";
+
+import { cn } from "@/utils/cn";
+
+import TabItem, { TabItemProps } from "./TabItem";
+
+const tabContentCSS = cva("w-full text-base text-black", {
+  variants: {
+    variant: {
+      enclosed: "rounded-sm border border-[#CCCCCC] bg-[#F9F9F9] shadow",
+      underlined: "",
+      solid: "",
+    },
+  },
+});
+
+interface TabProps
+  extends VariantProps<typeof tabContentCSS>,
+    ComponentPropsWithRef<"div"> {}
+
+const Tab = ({ children, className, ...props }: TabProps) => {
+  const { variant } = props;
+
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const items = useMemo(
+    () =>
+      Children.map(children as ReactElement<TabItemProps>[], (child, index) =>
+        cloneElement(child, {
+          ...child.props,
+          variant,
+          isActive: index === activeTabIndex,
+          onClick: () => setActiveTabIndex(index),
+        }),
+      ),
+    [children, activeTabIndex, variant],
+  );
+
+  const activeContent = items[activeTabIndex].props.children;
+
+  return (
+    <div className="w-full">
+      <div className={cn("flex", variant === "solid" && "gap-2")}>{items}</div>
+      <div className={cn(tabContentCSS({ variant }), className)}>
+        {activeContent}
+      </div>
+    </div>
+  );
+};
+
+Tab.Item = TabItem;
+
+export default Tab;

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -16,7 +16,7 @@ import TabItem, { TabItemProps } from "./TabItem";
 const tabContentCSS = cva("w-full text-base text-black", {
   variants: {
     variant: {
-      enclosed: "rounded-sm border border-[#CCCCCC] bg-[#F9F9F9] shadow",
+      enclosed: "border-gray-middle bg-white-dull rounded-sm border shadow",
       underlined: "",
       solid: "",
     },

--- a/src/stories/components/Tab.stories.tsx
+++ b/src/stories/components/Tab.stories.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { BiCalendarEvent } from "react-icons/bi";
+import { RiListUnordered } from "react-icons/ri";
+
+import DatePicker from "@/components/DatePicker";
+import Tab from "@/components/Tab";
+
+const meta: Meta<typeof Tab> = {
+  title: "components/Tab",
+  tags: ["autodocs"],
+  component: Tab,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tab>;
+
+export const Enclosed: Story = {
+  render: function Render() {
+    return (
+      <Tab variant="enclosed">
+        <Tab.Item label="장소로 검색">Content 1</Tab.Item>
+        <Tab.Item label="시간으로 검색">Content 2</Tab.Item>
+        <Tab.Item label="반복 예약" disabled>
+          Content 3
+        </Tab.Item>
+      </Tab>
+    );
+  },
+};
+
+export const Underlined: Story = {
+  render: function Render() {
+    return (
+      <Tab variant="underlined">
+        <Tab.Item label="예약 현황">Content 1</Tab.Item>
+        <Tab.Item label="나의 예약">Content 2</Tab.Item>
+      </Tab>
+    );
+  },
+};
+
+export const Solid: Story = {
+  render: function Render() {
+    return (
+      <Tab variant="solid">
+        <Tab.Item icon={BiCalendarEvent}>Content 1</Tab.Item>
+        <Tab.Item icon={RiListUnordered}>Content 2</Tab.Item>
+      </Tab>
+    );
+  },
+};
+
+export const Overlapped: Story = {
+  render: function Render() {
+    const [date, setDate] = useState<Date | undefined>(undefined);
+
+    return (
+      <Tab variant="enclosed" className="p-4">
+        <Tab.Item label="예약내역 관리">
+          <Tab variant="solid" className="flex">
+            <Tab.Item icon={BiCalendarEvent}>
+              <DatePicker date={date} onChange={setDate} />
+              <Tab variant="underlined">
+                <Tab.Item label="교회일정"></Tab.Item>
+              </Tab>
+            </Tab.Item>
+            <Tab.Item icon={RiListUnordered}>Content 2</Tab.Item>
+          </Tab>
+        </Tab.Item>
+        <Tab.Item label="교회일정 관리">Content</Tab.Item>
+      </Tab>
+    );
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,10 +5,20 @@ export default {
     extend: {
       colors: {
         primary: {
+          light: "#96C2FF",
           DEFAULT: "#06367A",
-          lighten: "#96C2FF",
         },
         black: "#1A1A1A",
+        white: {
+          DEFAULT: "#FFFFFF",
+          dull: "#F9F9F9",
+        },
+        gray: {
+          light: "#F2F2F2",
+          middle: "#CCCCCC",
+          dull: "#9C9C9C",
+          dark: "#616161",
+        },
         sunday: "#FF6161",
         saturday: "#4D54FF",
       },


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #16

## 📝작업 내용

합성 컴포넌트 패턴으로 `Tab` 컴포넌트를 구현했습니다.
- `variant`: `enclosed`, `underlined`, `solid`
- `<Tab>` `className`으로 선택된 Tab에 해당하는 Content 영역 스타일을 지정할 수 있습니다.

### 사용 예시
```javascript
<Tab variant="enclosed">
  <Tab.Item label="장소로 검색">Content 1</Tab.Item>
  <Tab.Item label="시간으로 검색">Content 2</Tab.Item>
  {/* Tab 비활성화 */}
  <Tab.Item label="반복 예약" disabled>Content 3</Tab.Item>
</Tab>
```
### 스크린샷
|variant|이미지|
|-|-|
|`enclosed`|<img src="https://github.com/jeeseongmin/spotOn/assets/42732729/74741293-00e4-4775-b855-1a129157724f">|
|`underlined`|<img src="https://github.com/jeeseongmin/spotOn/assets/42732729/354b7ee1-fdfe-4989-9ce6-0c448db388f3">|
|`solid`|<img src="https://github.com/jeeseongmin/spotOn/assets/42732729/6ed3a460-afb0-4674-88af-558aa70c9cfa">|

### 기타 작업
- `tailwind.config.js`에 gray 색상 팔레트를 추가했습니다.
  ex) MiddleGray 텍스트 색상 (피그마 와이어프레임) → `text-gray-middle`로 사용


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

- 서비스에서 사용되는 Tab들이 잘 추상화 되었는지 모르겠네요😓 적절하지 못한 부분이 있다면 코멘트 남겨주세요!
- 아래 같은 경우는 어떤 식으로 구현하면 좋을까요? `승인요청`, `전체/일반예약/반복예약`은 Tab 형식으로 구분되고 `전체`, `일반예약`, `반복예약`은 필터 버튼이어서 Tab으로 구현하기가 애매하다는 느낌이 듭니다..
  일단 이 부분은 배제하고 Tab 컴포넌트를 구현했습니다!
  <img src="https://github.com/jeeseongmin/spotOn/assets/42732729/c6bc44da-6e01-464e-9af9-3c489c744b50" width="60%">
