### PR TITLE
[#35] feat : DatePicker 연월 선택 기능 추가, Tab 활성된 탭 관리 기능 추가

### DIFF
--- a/src/components/DatePicker/Calendar.tsx
+++ b/src/components/DatePicker/Calendar.tsx
@@ -22,7 +22,7 @@ const CalendarItem = ({
     <div
       className={cn(
         "flex min-h-9 min-w-9 cursor-pointer items-center justify-center border font-light",
-        isInactive && "cursor-auto opacity-50",
+        isInactive && "cursor-auto opacity-30",
         dayOfTheWeek === 6 && "text-saturday",
         dayOfTheWeek === 0 && "text-red",
         isSelected

--- a/src/components/DatePicker/Calendar.tsx
+++ b/src/components/DatePicker/Calendar.tsx
@@ -1,4 +1,5 @@
 import dayjs, { type Dayjs } from "dayjs";
+import { useShallow } from "zustand/react/shallow";
 
 import {
   CalendarItemProps,
@@ -56,7 +57,9 @@ const Calendar = ({
   limit,
   onChangeSelectedDate,
 }: CalendarProps) => {
-  const { firstDayOfMonth, setFirstDayOfMonth } = useCalendarStore();
+  const [firstDayOfMonth, setFirstDayOfMonth] = useCalendarStore(
+    useShallow(state => [state.firstDayOfMonth, state.setFirstDayOfMonth]),
+  );
 
   const handleClickDate = (day: Dayjs, isInactive: boolean) => {
     if (isInactive) return;

--- a/src/components/DatePicker/DropdownYearMonthPicker.tsx
+++ b/src/components/DatePicker/DropdownYearMonthPicker.tsx
@@ -67,7 +67,7 @@ const DropdownYearMonthPicker = ({
 
   return (
     <div ref={dropdownRef} className="relative">
-      <div className="absolute left-1/2 top-8 z-50 flex w-fit -translate-x-1/2 flex-col overflow-hidden">
+      <div className="absolute left-1/2 top-8 z-50 -m-1 flex w-fit -translate-x-[calc(50%-0.25rem)] flex-col overflow-hidden p-1">
         <div
           className={cn(
             "hidden max-h-[245px] animate-dropdown-open bg-white shadow *:grow",

--- a/src/components/DatePicker/DropdownYearMonthPicker.tsx
+++ b/src/components/DatePicker/DropdownYearMonthPicker.tsx
@@ -5,6 +5,8 @@ import {
   useRef,
 } from "react";
 
+import type { Dayjs } from "dayjs";
+
 import { months, years } from "@/constants/calendar";
 import useModal from "@/hooks/useModal";
 import { useOutSideClick } from "@/hooks/useOutSideClick";
@@ -30,7 +32,15 @@ const Option = ({ children, isSelected, onClick, ...props }: OptionProps) => (
   </button>
 );
 
-const DropdownYearMonthPicker = () => {
+interface DropdownYearMonthPickerProps
+  extends Omit<ComponentPropsWithoutRef<"button">, "onClick"> {
+  onClick?: (date: Dayjs) => void;
+}
+
+const DropdownYearMonthPicker = ({
+  onClick,
+  className,
+}: DropdownYearMonthPickerProps) => {
   const firstDayOfMonth = useCalendarStore(state => state.firstDayOfMonth);
   const setFirstDayOfMonth = useCalendarStore(
     state => state.setFirstDayOfMonth,
@@ -46,16 +56,18 @@ const DropdownYearMonthPicker = () => {
 
     if (target.name === "year") {
       setFirstDayOfMonth(firstDayOfMonth.year(option).date(1));
+      onClick?.(firstDayOfMonth.year(option).date(1));
 
       return;
     }
 
     setFirstDayOfMonth(firstDayOfMonth.month(option).date(1));
+    onClick?.(firstDayOfMonth.month(option).date(1));
   };
 
   return (
     <div ref={dropdownRef} className="relative">
-      <div className="absolute left-1/2 top-8 z-40 flex w-fit -translate-x-1/2 flex-col overflow-hidden">
+      <div className="absolute left-1/2 top-8 z-50 flex w-fit -translate-x-1/2 flex-col overflow-hidden">
         <div
           className={cn(
             "hidden max-h-[245px] animate-dropdown-open bg-white shadow *:grow",
@@ -88,7 +100,7 @@ const DropdownYearMonthPicker = () => {
       </div>
       <button
         type="button"
-        className="flex font-light"
+        className={className}
         onClick={optionsModal.onToggle}
       >
         {firstDayOfMonth.format("YYYY. MM")}

--- a/src/components/DatePicker/DropdownYearMonthPicker.tsx
+++ b/src/components/DatePicker/DropdownYearMonthPicker.tsx
@@ -6,6 +6,7 @@ import {
 } from "react";
 
 import type { Dayjs } from "dayjs";
+import { useShallow } from "zustand/react/shallow";
 
 import { months, years } from "@/constants/calendar";
 import useModal from "@/hooks/useModal";
@@ -41,9 +42,8 @@ const DropdownYearMonthPicker = ({
   onClick,
   className,
 }: DropdownYearMonthPickerProps) => {
-  const firstDayOfMonth = useCalendarStore(state => state.firstDayOfMonth);
-  const setFirstDayOfMonth = useCalendarStore(
-    state => state.setFirstDayOfMonth,
+  const [firstDayOfMonth, setFirstDayOfMonth] = useCalendarStore(
+    useShallow(state => [state.firstDayOfMonth, state.setFirstDayOfMonth]),
   );
 
   const dropdownRef = useRef<HTMLDivElement>(null);

--- a/src/components/DatePicker/DropdownYearMonthPicker.tsx
+++ b/src/components/DatePicker/DropdownYearMonthPicker.tsx
@@ -1,0 +1,100 @@
+import {
+  ComponentPropsWithoutRef,
+  MouseEvent,
+  MouseEventHandler,
+  useRef,
+} from "react";
+
+import { months, years } from "@/constants/calendar";
+import useModal from "@/hooks/useModal";
+import { useOutSideClick } from "@/hooks/useOutSideClick";
+import useCalendarStore from "@/store/calendarStore";
+import { cn } from "@/utils/cn";
+
+interface OptionProps extends ComponentPropsWithoutRef<"button"> {
+  isSelected: boolean;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+}
+
+const Option = ({ children, isSelected, onClick, ...props }: OptionProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      "z-20 flex w-20 select-none items-center justify-center rounded-sm bg-white py-2.5 text-small text-black",
+      isSelected && "border border-primary bg-primary font-semibold text-white",
+    )}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+const DropdownYearMonthPicker = () => {
+  const firstDayOfMonth = useCalendarStore(state => state.firstDayOfMonth);
+  const setFirstDayOfMonth = useCalendarStore(
+    state => state.setFirstDayOfMonth,
+  );
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const optionsModal = useModal();
+  useOutSideClick(dropdownRef, () => optionsModal.onClose());
+
+  const handleClickOption = (e: MouseEvent<HTMLButtonElement>) => {
+    const target = e.currentTarget;
+    const option = Number(target.dataset.option);
+
+    if (target.name === "year") {
+      setFirstDayOfMonth(firstDayOfMonth.year(option).date(1));
+
+      return;
+    }
+
+    setFirstDayOfMonth(firstDayOfMonth.month(option).date(1));
+  };
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      <div className="absolute left-1/2 top-8 z-40 flex w-fit -translate-x-1/2 flex-col overflow-hidden">
+        <div
+          className={cn(
+            "hidden max-h-[245px] animate-dropdown-open bg-white shadow *:grow",
+            optionsModal.isOpen && "flex",
+          )}
+        >
+          <div className="flex-col overflow-y-scroll overscroll-contain scrollbar-hide">
+            {years.map(option => (
+              <Option
+                key={option}
+                name="year"
+                data-option={option}
+                isSelected={firstDayOfMonth.year() === option}
+                onClick={handleClickOption}
+              >{`${option}년`}</Option>
+            ))}
+          </div>
+          <div className="flex-col overflow-y-scroll overscroll-contain scrollbar-hide">
+            {months.map(option => (
+              <Option
+                key={option}
+                name="month"
+                data-option={option}
+                isSelected={firstDayOfMonth.month() === option}
+                onClick={handleClickOption}
+              >{`${option + 1}월`}</Option>
+            ))}
+          </div>
+        </div>
+      </div>
+      <button
+        type="button"
+        className="flex font-light"
+        onClick={optionsModal.onToggle}
+      >
+        {firstDayOfMonth.format("YYYY. MM")}
+      </button>
+    </div>
+  );
+};
+
+export default DropdownYearMonthPicker;

--- a/src/components/DatePicker/DropdownYearMonthPicker.tsx
+++ b/src/components/DatePicker/DropdownYearMonthPicker.tsx
@@ -8,7 +8,7 @@ import {
 import type { Dayjs } from "dayjs";
 import { useShallow } from "zustand/react/shallow";
 
-import { months, years } from "@/constants/calendar";
+import { months } from "@/constants/calendar";
 import useModal from "@/hooks/useModal";
 import { useOutSideClick } from "@/hooks/useOutSideClick";
 import useCalendarStore from "@/store/calendarStore";
@@ -35,10 +35,12 @@ const Option = ({ children, isSelected, onClick, ...props }: OptionProps) => (
 
 interface DropdownYearMonthPickerProps
   extends Omit<ComponentPropsWithoutRef<"button">, "onClick"> {
+  years: number[];
   onClick?: (date: Dayjs) => void;
 }
 
 const DropdownYearMonthPicker = ({
+  years,
   onClick,
   className,
 }: DropdownYearMonthPickerProps) => {

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -1,5 +1,6 @@
 import { Dayjs } from "dayjs";
 import { SlArrowLeft, SlArrowRight } from "react-icons/sl";
+import { useShallow } from "zustand/react/shallow";
 
 import Button from "@/components/Button";
 import Calendar from "@/components/DatePicker/Calendar";
@@ -14,8 +15,9 @@ interface DatePickerProps {
 }
 
 const DatePicker = ({ startDate, date, limit, onChange }: DatePickerProps) => {
-  const { firstDayOfMonth, setFirstDayOfMonth } = useCalendarStore();
-
+  const [firstDayOfMonth, setFirstDayOfMonth] = useCalendarStore(
+    useShallow(state => [state.firstDayOfMonth, state.setFirstDayOfMonth]),
+  );
   const goPreviousMonth = () =>
     setFirstDayOfMonth(firstDayOfMonth.date(0).date(1));
   const goNextMonth = () =>

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -27,7 +27,7 @@ const DatePicker = ({ startDate, date, limit, onChange }: DatePickerProps) => {
         <Button variant="custom" onClick={goPreviousMonth}>
           <SlArrowLeft size={10} />
         </Button>
-        <DropdownYearMonthPicker />
+        <DropdownYearMonthPicker className="flex font-light" />
         <Button variant="custom" onClick={goNextMonth}>
           <SlArrowRight size={10} />
         </Button>

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -5,6 +5,7 @@ import { useShallow } from "zustand/react/shallow";
 import Button from "@/components/Button";
 import Calendar from "@/components/DatePicker/Calendar";
 import DropdownYearMonthPicker from "@/components/DatePicker/DropdownYearMonthPicker";
+import { reservationYears } from "@/constants/calendar";
 import useCalendarStore from "@/store/calendarStore";
 
 interface DatePickerProps {
@@ -29,7 +30,10 @@ const DatePicker = ({ startDate, date, limit, onChange }: DatePickerProps) => {
         <Button variant="custom" onClick={goPreviousMonth}>
           <SlArrowLeft size={10} />
         </Button>
-        <DropdownYearMonthPicker className="flex font-light" />
+        <DropdownYearMonthPicker
+          years={reservationYears}
+          className="flex font-light"
+        />
         <Button variant="custom" onClick={goNextMonth}>
           <SlArrowRight size={10} />
         </Button>

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -1,10 +1,10 @@
 import { Dayjs } from "dayjs";
 import { SlArrowLeft, SlArrowRight } from "react-icons/sl";
 
+import Button from "@/components/Button";
+import Calendar from "@/components/DatePicker/Calendar";
+import DropdownYearMonthPicker from "@/components/DatePicker/DropdownYearMonthPicker";
 import useCalendarStore from "@/store/calendarStore";
-
-import Button from "../Button";
-import Calendar from "./Calendar";
 
 interface DatePickerProps {
   startDate?: Dayjs;
@@ -27,9 +27,7 @@ const DatePicker = ({ startDate, date, limit, onChange }: DatePickerProps) => {
         <Button variant="custom" onClick={goPreviousMonth}>
           <SlArrowLeft size={10} />
         </Button>
-        <div className="flex font-light">
-          {firstDayOfMonth.format("YYYY. MM")}
-        </div>
+        <DropdownYearMonthPicker />
         <Button variant="custom" onClick={goNextMonth}>
           <SlArrowRight size={10} />
         </Button>

--- a/src/components/Schedule/index.tsx
+++ b/src/components/Schedule/index.tsx
@@ -2,13 +2,15 @@ import dayjs from "dayjs";
 import { SlArrowLeft, SlArrowRight } from "react-icons/sl";
 
 import Button from "@/components/Button";
+import DropdownYearMonthPicker from "@/components/DatePicker/DropdownYearMonthPicker";
 import Reservation from "@/components/Schedule/Reservation";
 import Calendar from "@/pages/Home/components/Calendar";
 import useCalendarStore from "@/store/calendarStore";
 
 const Schedule = () => {
-  const { date, setDate, firstDayOfMonth, setFirstDayOfMonth } =
-    useCalendarStore(state => state);
+  const { date, setDate, setFirstDayOfMonth } = useCalendarStore(
+    state => state,
+  );
 
   const goPreviousMonth = () => {
     setFirstDayOfMonth(date.date(0).date(1));
@@ -33,9 +35,10 @@ const Schedule = () => {
           <Button variant="custom" onClick={goPreviousMonth}>
             <SlArrowLeft size={13} />
           </Button>
-          <div className="flex text-xl font-light leading-5">
-            {firstDayOfMonth.format("YYYY. MM")}
-          </div>
+          <DropdownYearMonthPicker
+            className="flex text-xl font-light leading-5"
+            onClick={setDate}
+          />
           <Button variant="custom" onClick={goNextMonth}>
             <SlArrowRight size={13} />
           </Button>

--- a/src/components/Schedule/index.tsx
+++ b/src/components/Schedule/index.tsx
@@ -1,5 +1,5 @@
-import dayjs from "dayjs";
 import { SlArrowLeft, SlArrowRight } from "react-icons/sl";
+import { useShallow } from "zustand/react/shallow";
 
 import Button from "@/components/Button";
 import DropdownYearMonthPicker from "@/components/DatePicker/DropdownYearMonthPicker";
@@ -8,8 +8,13 @@ import Calendar from "@/pages/Home/components/Calendar";
 import useCalendarStore from "@/store/calendarStore";
 
 const Schedule = () => {
-  const { date, setDate, setFirstDayOfMonth } = useCalendarStore(
-    state => state,
+  const [date, setDate, setFirstDayOfMonth, reset] = useCalendarStore(
+    useShallow(state => [
+      state.date,
+      state.setDate,
+      state.setFirstDayOfMonth,
+      state.reset,
+    ]),
   );
 
   const goPreviousMonth = () => {
@@ -20,11 +25,6 @@ const Schedule = () => {
   const goNextMonth = () => {
     setFirstDayOfMonth(date.date(date.daysInMonth() + 1));
     setDate(date.date(date.daysInMonth() + 1));
-  };
-
-  const reset = () => {
-    setDate(dayjs(new Date()));
-    setFirstDayOfMonth(dayjs(new Date()).date(1));
   };
 
   return (

--- a/src/components/Schedule/index.tsx
+++ b/src/components/Schedule/index.tsx
@@ -4,6 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import Button from "@/components/Button";
 import DropdownYearMonthPicker from "@/components/DatePicker/DropdownYearMonthPicker";
 import Reservation from "@/components/Schedule/Reservation";
+import { scheduleYears } from "@/constants/calendar";
 import Calendar from "@/pages/Home/components/Calendar";
 import useCalendarStore from "@/store/calendarStore";
 
@@ -36,6 +37,7 @@ const Schedule = () => {
             <SlArrowLeft size={13} />
           </Button>
           <DropdownYearMonthPicker
+            years={scheduleYears}
             className="flex text-xl font-light leading-5"
             onClick={setDate}
           />

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -4,12 +4,12 @@ import {
   ReactElement,
   cloneElement,
   useMemo,
-  useState,
 } from "react";
 
 import { VariantProps, cva } from "class-variance-authority";
+import { useSearchParams } from "react-router-dom";
 
-import TabItem, { TabItemProps } from "@/components/Tab/TabItem";
+import TabItem, { type TabItemProps } from "@/components/Tab/TabItem";
 import { cn } from "@/utils/cn";
 
 const tabContentCSS = cva("w-full text-base text-black", {
@@ -22,6 +22,8 @@ const tabContentCSS = cva("w-full text-base text-black", {
   },
 });
 
+const QUERYSTRING_KEY_TAB = "tab";
+
 interface TabProps
   extends VariantProps<typeof tabContentCSS>,
     ComponentPropsWithRef<"div"> {}
@@ -33,7 +35,9 @@ interface TabProps
 const Tab = ({ children, className, ...props }: TabProps) => {
   const { variant } = props;
 
-  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTabIndex = Number(searchParams.get(QUERYSTRING_KEY_TAB)) || 0;
+
   const items = useMemo(
     () =>
       Children.map(children as ReactElement<TabItemProps>[], (child, index) =>
@@ -41,9 +45,15 @@ const Tab = ({ children, className, ...props }: TabProps) => {
           ...child.props,
           variant,
           isActive: index === activeTabIndex,
-          onClick: () => setActiveTabIndex(index),
+          onClick: () => {
+            setSearchParams(
+              { [QUERYSTRING_KEY_TAB]: String(index) },
+              { replace: true },
+            );
+          },
         }),
       ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [children, activeTabIndex, variant],
   );
 

--- a/src/constants/calendar.ts
+++ b/src/constants/calendar.ts
@@ -24,7 +24,11 @@ export const orderText = [
 export const cycleTypeByEnglish = ["daily", "weekly", "monthly"];
 export const cycleTypeByKorean = ["매일", "매주", "매월"];
 
-export const years = Array.from({ length: 10 }, (_, i) => dayjs().year() + i);
+export const scheduleYears = Array.from(
+  { length: 3 },
+  (_, i) => dayjs().year() - 2 + i,
+);
+export const reservationYears = [dayjs().year()];
 export const months = Array.from({ length: 12 }, (_, i) => i);
 
 export interface CalendarProps {

--- a/src/constants/calendar.ts
+++ b/src/constants/calendar.ts
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
-import { Dayjs } from "dayjs";
+import dayjs, { type Dayjs } from "dayjs";
 
 export const daysOfTheWeek = ["일", "월", "화", "수", "목", "금", "토"];
 export const daysOfTheWeekByEnglish = [
@@ -23,6 +23,9 @@ export const orderText = [
 
 export const cycleTypeByEnglish = ["daily", "weekly", "monthly"];
 export const cycleTypeByKorean = ["매일", "매주", "매월"];
+
+export const years = Array.from({ length: 10 }, (_, i) => dayjs().year() + i);
+export const months = Array.from({ length: 12 }, (_, i) => i);
 
 export interface CalendarProps {
   startDate?: Dayjs;

--- a/src/constants/store.ts
+++ b/src/constants/store.ts
@@ -1,8 +1,13 @@
 import { Dayjs } from "dayjs";
 
-export type CalendarType = {
+export type CalendarState = {
   date: Dayjs;
   firstDayOfMonth: Dayjs;
+};
+
+export type CalendarAction = {
   setDate: (_date: Dayjs) => void;
   setFirstDayOfMonth: (_firstDayOfMonth: Dayjs) => void;
+  reset: () => void;
+  resetFirstDayOfMonth: () => void;
 };

--- a/src/pages/Home/components/Calendar.tsx
+++ b/src/pages/Home/components/Calendar.tsx
@@ -1,4 +1,5 @@
 import dayjs from "dayjs";
+import { useShallow } from "zustand/react/shallow";
 
 import Reservation from "@/components/Schedule/Reservation";
 import { CalendarItemProps, daysOfTheWeek } from "@/constants/calendar";
@@ -79,8 +80,14 @@ const CalendarItem = ({
 };
 
 const Calendar = () => {
-  const { date, setDate, firstDayOfMonth, setFirstDayOfMonth } =
-    useCalendarStore(state => state);
+  const [date, setDate, firstDayOfMonth, setFirstDayOfMonth] = useCalendarStore(
+    useShallow(state => [
+      state.date,
+      state.setDate,
+      state.firstDayOfMonth,
+      state.setFirstDayOfMonth,
+    ]),
+  );
 
   return (
     <table className="flex h-full w-full border-collapse flex-col">

--- a/src/pages/Home/components/DailyReservationList.tsx
+++ b/src/pages/Home/components/DailyReservationList.tsx
@@ -6,7 +6,7 @@ import ReservationCard from "@/pages/Home/components/ReservationCard";
 import useCalendarStore from "@/store/calendarStore";
 
 const DailyReservationList = () => {
-  const { date } = useCalendarStore(state => state);
+  const date = useCalendarStore(state => state.date);
 
   const [dailyReservations, setDailyReservations] = useState(
     reservations.filter((reservation: TempType) => {

--- a/src/pages/Reservation/components/ReservationTab/PlaceSearchTab/index.tsx
+++ b/src/pages/Reservation/components/ReservationTab/PlaceSearchTab/index.tsx
@@ -9,10 +9,14 @@ import { reservedTimes } from "@/dummy/reservation";
 import PlacePicker from "@/pages/Reservation/components/PlacePicker";
 import TimeTablePicker from "@/pages/Reservation/components/ReservationTab/PlaceSearchTab/TimeTablePicker";
 import ReservationTabLayout from "@/pages/Reservation/components/ReservationTab/ReservationTabLayout";
+import useCalendarStore from "@/store/calendarStore";
 
 const PlaceSearchTab = () => {
   const { control, getValues, reset, resetField } = useFormContext();
   useWatch({ name: "place" });
+  const resetFirstDayOfMonth = useCalendarStore(
+    state => state.resetFirstDayOfMonth,
+  );
 
   const timeSelectErrorMessage = getValues("place")
     ? ""
@@ -20,6 +24,7 @@ const PlaceSearchTab = () => {
 
   useEffect(() => {
     reset();
+    resetFirstDayOfMonth();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/pages/Reservation/components/ReservationTab/RecurringReservationTab/index.tsx
+++ b/src/pages/Reservation/components/ReservationTab/RecurringReservationTab/index.tsx
@@ -9,9 +9,13 @@ import DropdownTimePicker from "@/pages/Reservation/components/DropdownTimePicke
 import PlacePicker from "@/pages/Reservation/components/PlacePicker";
 import SelectRepeatType from "@/pages/Reservation/components/ReservationTab/RecurringReservationTab/SelectRepeatType";
 import ReservationTabLayout from "@/pages/Reservation/components/ReservationTab/ReservationTabLayout";
+import useCalendarStore from "@/store/calendarStore";
 
 const RecurringReservationTab = () => {
   const { control, getValues, setValue, reset } = useFormContext();
+  const resetFirstDayOfMonth = useCalendarStore(
+    state => state.resetFirstDayOfMonth,
+  );
 
   useWatch({ name: ["date", "time", "startDate", "endDate"] });
 
@@ -25,12 +29,14 @@ const RecurringReservationTab = () => {
 
   useEffect(() => {
     reset();
+    resetFirstDayOfMonth();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const resetEndDate = () => {
     setValue("endDate", "");
   };
+
   return (
     <ReservationTabLayout>
       <ReservationTabLayout.Left title="날짜 선택" type="recurring">

--- a/src/pages/Reservation/components/ReservationTab/TimeSearchTab/index.tsx
+++ b/src/pages/Reservation/components/ReservationTab/TimeSearchTab/index.tsx
@@ -8,10 +8,14 @@ import { availablePlaces, placesByFloor } from "@/dummy/places";
 import DropdownTimePicker from "@/pages/Reservation/components/DropdownTimePicker";
 import PlacePicker from "@/pages/Reservation/components/PlacePicker";
 import ReservationTabLayout from "@/pages/Reservation/components/ReservationTab/ReservationTabLayout";
+import useCalendarStore from "@/store/calendarStore";
 
 const TimeSearchTab = () => {
   const { control, getValues, reset, resetField } = useFormContext();
   useWatch({ name: ["date", "time"] });
+  const resetFirstDayOfMonth = useCalendarStore(
+    state => state.resetFirstDayOfMonth,
+  );
 
   const isSelectedTime =
     getValues("time").length > 0 &&
@@ -23,6 +27,7 @@ const TimeSearchTab = () => {
 
   useEffect(() => {
     reset();
+    resetFirstDayOfMonth();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/pages/Reservation/index.tsx
+++ b/src/pages/Reservation/index.tsx
@@ -81,7 +81,7 @@ const ReservationPage = () => {
               <ReservationDetails user={user} />
             </ReservationModal.Content>
             <ReservationModal.Footer>
-              <Link to={MYPAGE_MAIN_URL}>
+              <Link to={`${MYPAGE_MAIN_URL}?tab=1`}>
                 <Button variant="outlined">나의 예약</Button>
               </Link>
               <Button variant="primary" onClick={handleClickOkButton}>

--- a/src/store/calendarStore.ts
+++ b/src/store/calendarStore.ts
@@ -1,14 +1,20 @@
 import dayjs from "dayjs";
 import { create } from "zustand";
 
-import { CalendarType } from "@/constants/store";
+import type { CalendarAction, CalendarState } from "@/constants/store";
 
-const useCalendarStore = create<CalendarType>(set => ({
-  date: dayjs(new Date()),
+const initialState: CalendarState = {
+  date: dayjs(),
   firstDayOfMonth: dayjs().date(1),
+};
 
+const useCalendarStore = create<CalendarState & CalendarAction>(set => ({
+  ...initialState,
   setDate: newState => set({ date: newState }),
-  setFirstDayOfMonth: newState => set({ firstDayOfMonth: newState }),
+  setFirstDayOfMonth: newState => set({ firstDayOfMonth: newState.date(1) }),
+  reset: () => set(initialState),
+  resetFirstDayOfMonth: () =>
+    set({ firstDayOfMonth: initialState.firstDayOfMonth }),
 }));
 
 export default useCalendarStore;


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #35

## 📝작업 내용
### DatePicker
연월 선택을 위한 `DropdownYearMonthPicker`을 추가했습니다.
- 연도는 `올해 + 9년`까지 선택 가능합니다.

### Tab
활성된 탭을 querystring으로 관리합니다.
- 새로고침 시에도 활성된 탭이 유지됩니다.
- 특정 탭이 활성된 상태인 페이지로 이동할 수 있습니다.
- 브라우저 뒤로가기 버튼 클릭 시 이전 Tab이 아닌 이전 페이지로 이동하도록 `replace` 옵션을 `true`로 설정했습니다.

### 기타 작업
- `CalendarStore`에 전체 state 초기화, `firstDayOfMonth` 초기화를 위한 action을 추가했습니다.
  - 예약 페이지에서 Tab을 이동할 때마다 `firstDayOfMonth`를 초기화합니다.
- `CalendarStore`에서 state 및 action을 가져올 때 렌더링 최적화를 위해 `selector`를 추가했습니다. ([참고한 문서](https://github.com/pmndrs/zustand#selecting-multiple-state-slices))

### 스크린샷 (선택)
<img src="https://github.com/jeeseongmin/spotOn/assets/42732729/f525fbf4-b7c7-47bb-b4da-f088e48402fa" width="40%">
